### PR TITLE
chore: .gitignore, tsconfig.json の設定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# editor
+.idea
+.vscode

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,20 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",
       "esnext"
     ],
-    "allowJs": true,
+    "allowJs": false,
+    "allowUnusedLabels": false,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -22,5 +24,9 @@
   },
   "include": [
     "src"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/.*/"
   ]
 }


### PR DESCRIPTION
- エディタ側の設定は他開発者と共有しないため .gitignore を設定
- tsconfig の設定変更
  -  IE11 はサポートしないため `"target": "es6"` を設定
  - JSファイルは利用しないので `"allowJs": "false"` を設定
  - 実装のエンバグを防ぐため `"allowUnusedLabels": false` および `"noUnusedLocals": true` を設定
  - コード補完、およびコンパイルパフォーマンスを向上させるため `"exclude": [
    "**/node_modules",
    "**/.*/"
  ]` を設定
    - 参考
      - https://github.com/microsoft/TypeScript/wiki/Performance#misconfigured-include-and-exclude